### PR TITLE
Make package build on GHC 8.8 and above

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-08-29  GambPang <ics@gambolingpangolin.com>
+
+	* Data/Bitstream/Fusion/Monadic.hs: Adds `MonadFail` to context
+	where code uses explicit `fail`.
+	* bitstream.cabal: Bump version to 0.3.0.1, adds test success
+	cases, adds library dependency to test suites.
+
 2015-03-04  PHO  <pho@cielonegro.org>
 
 	* Data/Bitstream.hs, Data/Bitstream/Lazy.hs: Fix Haddock comments

--- a/Data/Bitstream/Fusion/Monadic.hs
+++ b/Data/Bitstream/Fusion/Monadic.hs
@@ -78,7 +78,11 @@ genericDrop n0 (Stream step s0 sz) = Stream step' (s0, Just n0) (toMax sz)
                  Skip    s' → return $ Skip    (s', Nothing)
                  Done       → return Done
 
+#if __GLASGOW_HASKELL__ >= 808
+genericIndex ∷ (MonadFail m, Monad m, Integral n, Show n) ⇒ Stream m α → n → m α
+#else
 genericIndex ∷ (Monad m, Integral n, Show n) ⇒ Stream m α → n → m α
+#endif
 {-# INLINE [0] genericIndex #-}
 {-# RULES "genericIndex → (!!)" genericIndex = (!!) #-}
 #if MIN_VERSION_vector(0,11,0)

--- a/bitstream.cabal
+++ b/bitstream.cabal
@@ -6,7 +6,7 @@ Description:
         fusion. This is like @bytestring@ but stores bits instead of
         bytes.
 
-Version: 0.3.0.0
+Version: 0.3.0.1
 License: PublicDomain
 License-File: COPYING
 Author: PHO <pho at cielonegro dot org>
@@ -15,7 +15,7 @@ Stability: experimental
 Homepage: https://github.com/phonohawk/bitstream
 Bug-Reports: https://github.com/phonohawk/bitstream/issues
 Category: Data
-Tested-With: GHC == 7.6.2
+Tested-With: GHC == 7.6.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.2
 Cabal-Version: >= 1.10
 Build-Type: Simple
 Extra-Source-Files:
@@ -64,6 +64,7 @@ Test-Suite test-strict-bitstream
         QuickCheck           >= 2.5,
         base                 == 4.*,
         base-unicode-symbols == 0.2.*,
+        bitstream,
         bytestring           >= 0.9 && < 0.11,
         vector               >= 0.10 && < 0.13
     if !impl(ghc >= 8.0)
@@ -82,6 +83,7 @@ Test-Suite test-lazy-bitstream
         QuickCheck           >= 2.5,
         base                 == 4.*,
         base-unicode-symbols == 0.2.*,
+        bitstream,
         bytestring           >= 0.9 && < 0.11,
         vector               >= 0.10 && < 0.13
     if !impl(ghc >= 8.0)


### PR DESCRIPTION
GHC 8.8 removed `fail` from the `Monad` typeclass.  For recent compiler versions, uses of `fail` must have a `MonadFail` constraint.